### PR TITLE
generate a deck slightly differently, fix pattern match on rules

### DIFF
--- a/set.pl
+++ b/set.pl
@@ -1,70 +1,58 @@
-%% A card is defined by its number, color, shape, and fill. 
-card --> num, fill, color, shape.
+shape(S) :- member(S, [oval, diamond, squiggle]).
+num(N) :- member(N, [one, two, three]).
+fill(F) :- member(F, [filled, clear, shaded]).
+color(C) :- member(C, [red, green, purple]).
 
-%% The number of shapes on a card can be one, two, or three.
-num --> [one].
-num --> [two].
-num --> [three].
 
-%% The fill of the shapes on a card can be solid, empty, or striped.
-fill --> [solid].
-fill --> [empty].
-fill --> [striped].
 
-%% The color of the shapes on a card can be red, green, or purple.
-color --> [red].
-color --> [green].
-color --> [purple].
-
-%% The shape of the shapes on a card can be diamond, oval, or squiggle. 
-shape --> [diamond].
-shape --> [oval].
-shape --> [squiggle].
+deck(Cs) :-
+    findall(card(N, F, C, S), 
+      (num(N), fill(F), color(C), shape(S)), Cs).
 
 %% Three cards whose numbers are all different.
-allDiffNums(card([A,_,_,_]), card([B,_,_,_]), card([C,_,_,_])) :-
+allDiffNums(card(A,_,_,_), card(B,_,_,_), card(C,_,_,_)) :-
 	\=(A,B),
 	\=(B,C),
 	\=(C,A).
 
 %% Three cards whose numbers are all the same.
-allSameNums(card([A,_,_,_]), card([B,_,_,_]), card([C,_,_,_])) :-
+allSameNums(card(A,_,_,_), card(B,_,_,_), card(C,_,_,_)) :-
 	=(A,B),
 	=(B,C),
 	=(C,A).
 
 %% Three cards whose fills are all different.
-allDiffFills(card([_,A,_,_]), card([_,B,_,_]), card([_,C,_,_])) :-
+allDiffFills(card(_,A,_,_), card(_,B,_,_), card(_,C,_,_)) :-
 	\=(A,B),
 	\=(B,C),
 	\=(C,A).
 
 %% Three cards whose fills are all the same.
-allSameFills(card([_,A,_,_]), card([_,B,_,_]), card([_,C,_,_])) :-
+allSameFills(card(_,A,_,_), card(_,B,_,_), card(_,C,_,_)) :-
 	=(A,B),
 	=(B,C),
 	=(C,A).
 
 %% Three cards whose colors are all different.
-allDiffColors(card([_,_,A,_]), card([_,_,B,_]), card([_,_,C,_])) :-
+allDiffColors(card(_,_,A,_), card(_,_,B,_), card(_,_,C,_)) :-
 	\=(A,B),
 	\=(B,C),
 	\=(C,A).
 
 %% Three cards whose colors are all the same.
-allSameColors(card([_,_,A,_]), card([_,_,B,_]), card([_,_,C,_])) :-
+allSameColors(card(_,_,A,_), card(_,_,B,_), card(_,_,C,_)) :-
 	=(A,B),
 	=(B,C),
 	=(C,A).
 
 %% Three cards whose shapes are all different.
-allDiffShapes(card([_,_,_,A]), card([_,_,_,B]), card([_,_,_,C])) :-
+allDiffShapes(card(_,_,_,A), card(_,_,_,B), card(_,_,_,C)) :-
 	\=(A,B),
 	\=(B,C),
 	\=(C,A).
 
 %% Three cards whose shapes are all the same.
-allSameShapes(card([_,_,_,A]), card([_,_,_,B]), card([_,_,_,C])) :-
+allSameShapes(card(_,_,_,A), card(_,_,_,B), card(_,_,_,C)) :-
 	=(A,B),
 	=(B,C),
 	=(C,A).
@@ -89,7 +77,14 @@ sameOrDiffShapes(A,B,C) :- allSameShapes(A,B,C).
 %% (number, fill, color, and shape) is either all the same or 
 %% all different, in any combination. 
 set(A,B,C) :-
-	sameOrDiffNums(A,B,C),
+  deck(Cs), 
+  member(A, Cs),
+  member(B, Cs),
+  member(C, Cs),
+	\=(A,B),
+	\=(B,C),
+	\=(C,A),
+        sameOrDiffNums(A,B,C),
 	sameOrDiffFills(A,B,C),
 	sameOrDiffColors(A,B,C),
 	sameOrDiffShapes(A,B,C).


### PR DESCRIPTION
Hi, 
I made some changes to your set ruleset so it can answer a couple of questions I had about set. I like how you approached it. 

```
?- deck(Cs), length(Cs, N).
Cs = [card(one, filled, red, oval), card(one, filled, red, diamond), card(one, filled, red, squiggle), card(one, filled, green, oval), card(one, filled, green, diamond), card(one, filled, green, squiggle), card(one, filled, purple, oval), card(one, filled, purple, diamond), card(..., ..., ..., ...)|...],
N = 81.
```


```
?- findall(X, set(A,B,C), Sets), length(Sets, L).
Sets = [_44984, _44978, _44972, _44966, _44960, _44954, _44948, _44942, _44936|...],
L = 6480.
```
